### PR TITLE
Update Makefile

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -116,7 +116,7 @@ obj-$(CONFIG_HAS_IOMEM) += memremap.o
 $(obj)/configs.o: $(obj)/config_data.h
 
 targets += config_data.gz
-$(obj)/config_data.gz: arch/arm64/configs/raphael-vts_defconfig FORCE
+$(obj)/config_data.gz: arch/arm64/configs/raphael_defconfig FORCE
 	$(call if_changed,gzip)
 
       filechk_ikconfiggz = (echo "static const char kernel_config_data[] __used = MAGIC_START"; cat $< | scripts/basic/bin2c; echo "MAGIC_END;")


### PR DESCRIPTION
Makeconfig now uses raphael_defconfig instead of raphael-vts_defconfig to update /proc/config.gz
(Everytime i checked /proc/config.gz it always showed wrong (old config). This solves it.